### PR TITLE
Add support for enabling PWS with local persistence

### DIFF
--- a/routes/weatherProviders/local.ts
+++ b/routes/weatherProviders/local.ts
@@ -132,7 +132,7 @@ function saveQueue() {
 	}
 }
 
-if ( process.env.WEATHER_PROVIDER === "local" && process.env.LOCAL_PERSISTENCE ) {
+if ( process.env.PWS && process.env.LOCAL_PERSISTENCE ) {
 	if ( fs.existsSync( "observations.json" ) ) {
 		try {
 			queue = JSON.parse( fs.readFileSync( "observations.json", "utf8" ) );


### PR DESCRIPTION
If a PWS is set (right now only type `WU` actually has any meaning on the code), OpenSprinkler-Weather will automatically register the route `/weatherstation/updateweatherstation.php` to capture the WU stream.

However, it will only persist changes of the captured stream if the `WEATHER_PROVIDER` is set to `local`, which in my opinion is too rigid as one may want to build a list of observations prior to switching to `local` weather provider.

Therefore I suggest testing the presence of the `PWS` variable instead allowing for the capturing system to fully work without having to switch providers.

I will also open this PR on the upstream repository. If it gets traction, then we can simply merge back on this repository.